### PR TITLE
chore: format src/knowledge/README_knowledge.md

### DIFF
--- a/src/knowledge/README_knowledge.md
+++ b/src/knowledge/README_knowledge.md
@@ -29,10 +29,10 @@ crocbot knowledge remove https://example.com/docs/guide
 
 ## Run Commands
 
-| Command | Purpose |
-|---------|---------|
-| `crocbot knowledge import <source>` | Import URL, file, or text |
-| `crocbot knowledge list` | List all imported sources |
+| Command                             | Purpose                      |
+| ----------------------------------- | ---------------------------- |
+| `crocbot knowledge import <source>` | Import URL, file, or text    |
+| `crocbot knowledge list`            | List all imported sources    |
 | `crocbot knowledge remove <source>` | Remove source and its chunks |
 
 ## Architecture


### PR DESCRIPTION
## Summary
Fixes the `format` CI check failure by running `oxfmt --write` on `src/knowledge/README_knowledge.md`.

The only change is markdown table column alignment — no logic touched.

## Root cause
The markdown table in `README_knowledge.md` had unaligned column separators. `oxfmt` (the project's formatter) normalises these, but the file was never reformatted after it was written.

## Fix
```
pnpm run format:fix
```
(scoped to the affected file via `oxfmt --write src/knowledge/README_knowledge.md`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only formatting change with no runtime or logic impact.
> 
> **Overview**
> Fixes a formatting/CI issue by reformatting the `Run Commands` markdown table in `src/knowledge/README_knowledge.md` (aligns headers/separators and spacing).
> 
> No functional or behavior changes; this is a docs-only whitespace/alignment update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a57bb97f8af79af4a684a4a360a1f34aabd29838. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->