### PR TITLE
fix(test): align config path candidates test with path.resolve() on Windows

### DIFF
--- a/src/config/paths.test.ts
+++ b/src/config/paths.test.ts
@@ -46,7 +46,9 @@ describe("state + config path candidates", () => {
   it("orders default config candidates as new then legacy", () => {
     const home = "/home/test";
     const candidates = resolveDefaultConfigCandidates({} as NodeJS.ProcessEnv, () => home);
-    expect(candidates[0]).toBe(path.join(home, ".crocbot", "crocbot.json"));
-    expect(candidates[1]).toBe(path.join(home, ".crocbot", "crocbot.json"));
+    // resolveRequiredHomeDir calls path.resolve() internally, so expectations must match
+    const resolvedHome = path.resolve(home);
+    expect(candidates[0]).toBe(path.join(resolvedHome, ".crocbot", "crocbot.json"));
+    expect(candidates[1]).toBe(path.join(resolvedHome, ".crocbot", "crocbot.json"));
   });
 });


### PR DESCRIPTION
## Summary
Fixes the 1 failing test in `src/config/paths.test.ts` on Windows:
> *"orders default config candidates as new then legacy"*

## Root cause
`resolveRequiredHomeDir()` calls `path.resolve()` on the raw homedir value before returning it. On Linux this is a no-op for absolute paths, but on Windows `path.resolve('/home/test')` prefixes the current drive letter (e.g. `C:\home\test`).

The test expectation used the raw `home` string (`/home/test`) directly in `path.join()`, so on Windows the expected path lacked the drive letter while the actual candidate had it — causing a mismatch.

## Fix
Wrap the expected home value in `path.resolve(home)` so both sides go through identical normalisation on every platform.

No production code changed — test only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that aligns expected path normalization; no runtime or config-resolution logic is modified.
> 
> **Overview**
> Fixes a failing Windows unit test in `src/config/paths.test.ts` by updating the expected default config candidate paths to use `path.resolve(home)` (matching `resolveRequiredHomeDir()` normalization) before `path.join()`.
> 
> No production code changes; this is a test-only adjustment to make path expectations consistent across platforms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3208dd450e79bb0b4a11bd3eb770a6835bd8672. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->